### PR TITLE
fix: don't generate frontend specific urls for the Learner Record MFE

### DIFF
--- a/src/components/ProgramRecord/ProgramRecordActions.jsx
+++ b/src/components/ProgramRecord/ProgramRecordActions.jsx
@@ -18,7 +18,7 @@ import { getProgramRecordUrl, getProgramRecordCsv } from './data/service';
 function ProgramRecordActions({
   showSendRecordButton, isPublic, toggleSendRecordModal, renderBackButton, username, programUUID, sharedRecordUUID,
 }) {
-  const [programRecordUrl, setProgramRecordUrl] = useState(sharedRecordUUID && `${getConfig().BASE_URL}/shared/${sharedRecordUUID}`);
+  const [programRecordUrl, setProgramRecordUrl] = useState(sharedRecordUUID && `${getConfig().CREDENTIALS_BASE_URL}/records/programs/shared/${sharedRecordUUID}`);
   const [showCopyTooltip, setShowCopyTooltip] = useState(false);
   const [showDownloadToast, setShowDownloadToast] = useState(false);
   const [downloadRecord, setDownloadRecord] = useState('default');


### PR DESCRIPTION
[APER-1975]

We're just going to generate links to the Credentials IDA and we will let the IDA figure out where the user should be directed to (either the LR MFE or the legacy frontend). This makes handlings URLs much easier if we just let the backend manage this work.