### PR TITLE
fix: create program link

### DIFF
--- a/src/components/ProgramRecord/data/service.js
+++ b/src/components/ProgramRecord/data/service.js
@@ -19,7 +19,7 @@ async function getProgramDetails(programUUID, isPublic) {
 export async function getProgramRecordUrl(programUUID, username) {
   const url = `${getConfig().CREDENTIALS_BASE_URL}/records/programs/${programUUID}/share`;
   try {
-    const response = await getAuthenticatedHttpClient().post(url, { username });
+    const response = await getAuthenticatedHttpClient().post(url, { username, withCredentials: true });
     return response;
   } catch (error) {
     throw new Error(error);


### PR DESCRIPTION
This is to fix a bug where learners are unable to create and copy a program record link. See [APER-2224](https://2u-internal.atlassian.net/browse/APER-2224) for more details.