### PR TITLE
fix: [FC-0006] verifiable credentials QR code modal instructions

### DIFF
--- a/src/components/ProgramCertificateModal/messages.js
+++ b/src/components/ProgramCertificateModal/messages.js
@@ -36,29 +36,29 @@ const messages = defineMessages({
   },
   certificateModalInstructionTitle: {
     id: 'credentials.modal.instruction.title',
-    defaultMessage: 'Download and install the app on your smartphone.',
+    defaultMessage:
+      'Follow this instructions below to get verifiable credential:',
     description: 'Title text of the instructions.',
   },
   certificateModalInstructionStep1: {
     id: 'credentials.modal.instruction.step1',
-    defaultMessage: 'Sign up for the app to identify yourself.',
+    defaultMessage: 'Download and install the app on your smartphone.',
     description: 'Text of step of the instructions.',
   },
   certificateModalInstructionStep2: {
     id: 'credentials.modal.instruction.step2',
-    defaultMessage:
-      'Open the application and select the option "Scan QR code". Scan the provided code.',
+    defaultMessage: 'Sign up for the app to identify yourself.',
     description: 'Text of step of the instructions.',
   },
   certificateModalInstructionStep3: {
     id: 'credentials.modal.instruction.step3',
     defaultMessage:
-      'Follow the instructions below to get the verifiable credential:',
+      'Open the application and select the option "Scan QR code". Scan the provided code.',
     description: 'Text of step of the instructions.',
   },
   certificateModalInstructionStep4: {
     id: 'credentials.modal.instruction.step4',
-    defaultMessage: 'Once you have successfully finished, close the modal.',
+    defaultMessage: 'Once you have successfully done - close modal.',
     description: 'Text of step of the instructions.',
   },
   certificateModalDeeplinkBtn: {

--- a/src/components/ProgramCertificateModal/messages.js
+++ b/src/components/ProgramCertificateModal/messages.js
@@ -37,12 +37,12 @@ const messages = defineMessages({
   certificateModalInstructionTitle: {
     id: 'credentials.modal.instruction.title',
     defaultMessage:
-      'Follow this instructions below to get verifiable credential:',
+      'Follow the instructions below to get a verifiable credential:',
     description: 'Title text of the instructions.',
   },
   certificateModalInstructionStep1: {
     id: 'credentials.modal.instruction.step1',
-    defaultMessage: 'Download and install the app on your smartphone.',
+    defaultMessage: 'Download and install the wallet app on your smartphone.',
     description: 'Text of step of the instructions.',
   },
   certificateModalInstructionStep2: {
@@ -53,12 +53,12 @@ const messages = defineMessages({
   certificateModalInstructionStep3: {
     id: 'credentials.modal.instruction.step3',
     defaultMessage:
-      'Open the application and select the option "Scan QR code". Scan the provided code.',
+      'Open the wallet application and select the option "Scan QR code". Then scan the image of QR code.',
     description: 'Text of step of the instructions.',
   },
   certificateModalInstructionStep4: {
     id: 'credentials.modal.instruction.step4',
-    defaultMessage: 'Once you have successfully done - close modal.',
+    defaultMessage: 'Once you have successfully done - close modal window.',
     description: 'Text of step of the instructions.',
   },
   certificateModalDeeplinkBtn: {


### PR DESCRIPTION
The PR fixes Verifiable Credentials feature bug.

There is a modal window with step-by-step instructions (see Figma design screenshot). Those steps were shuffled.

![image](https://github.com/openedx/frontend-app-learner-record/assets/2472913/3f272c05-36e0-4cf3-8491-21eadf738fd0)
