### PR TITLE
fix: add authenticatedpageroute so learner can create a shared record link

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,7 +34,7 @@ subscribe(APP_READY, () => {
             {getConfig().ENABLE_VERIFIABLE_CREDENTIALS && (
               <Route
                 path={ROUTES.VERIFIABLE_CREDENTIALS}
-                element={<ProgramCertificatesList />}
+                element={<AuthenticatedPageRoute><ProgramCertificatesList /></AuthenticatedPageRoute>}
               />
             )}
             <Route

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,7 @@ import { Routes, Route } from 'react-router-dom';
 import {
   APP_INIT_ERROR, APP_READY, subscribe, initialize, mergeConfig, getConfig,
 } from '@edx/frontend-platform';
-import { AppProvider, ErrorPage } from '@edx/frontend-platform/react';
+import { AppProvider, ErrorPage, AuthenticatedPageRoute } from '@edx/frontend-platform/react';
 import { HelmetProvider } from 'react-helmet-async';
 import Header from '@edx/frontend-component-header';
 import Footer from '@edx/frontend-component-footer';
@@ -29,7 +29,7 @@ subscribe(APP_READY, () => {
           <Routes>
             <Route
               path={ROUTES.PROGRAM_RECORDS}
-              element={<ProgramRecordsList />}
+              element={<AuthenticatedPageRoute><ProgramRecordsList /></AuthenticatedPageRoute>}
             />
             {getConfig().ENABLE_VERIFIABLE_CREDENTIALS && (
               <Route
@@ -43,7 +43,7 @@ subscribe(APP_READY, () => {
             />
             <Route
               path={ROUTES.PROGRAM_RECORD_ITEM}
-              element={<ProgramRecord isPublic={false} />}
+              element={<AuthenticatedPageRoute><ProgramRecord isPublic={false} /></AuthenticatedPageRoute>}
             />
           </Routes>
         ) : (


### PR DESCRIPTION
Description:

Resolves the bug APER-2606: [Learner unable to create public record without reauthenticating](https://2u-internal.atlassian.net/browse/APER-2603)

When the learner attempted to create a public record link, their clipboard copied the private URL and they weren't able to create a public URL unless they re-authenticated. This PR wraps the `ProgramRecordsList`, `ProgramCertificatesList`, and the private version of `ProgramRecord` with `AuthenticatedPageRoute`, which allows for the user to experience a redirect "to the login page when the route becomes active and the user is not authenticated" [source](https://openedx.github.io/frontend-platform/module-React.html#.AuthenticatedPageRoute). 

Note that the public view of `ProgramRecord` is not wrapped in the `AuthenticatedPageRoute`. This route needs to not be wrapped so that non-learners are able to access the public record via shared URL. 