### PR TITLE
feat:  make the "loading" message be accurate

### DIFF
--- a/src/components/ProgramRecord/ProgramRecord.jsx
+++ b/src/components/ProgramRecord/ProgramRecord.jsx
@@ -28,6 +28,7 @@ function ProgramRecord({ isPublic }) {
   const [recordDetails, setRecordDetails] = useState({});
   const [isLoaded, setIsLoaded] = useState(false);
   const [hasNoData, setHasNoData] = useState(false);
+  const [isNotFound, setNotFound] = useState(false);
   const [showSendRecordButton, setShowSendRecordButton] = useState(false);
 
   const [sendRecord, setSendRecord] = useState({
@@ -188,14 +189,30 @@ function ProgramRecord({ isPublic }) {
     </>
   );
 
+  const renderLoading = () => (
+    <>
+      {!isPublic && renderBackButton()}
+      <p>
+        <FormattedMessage
+          id="page.loading.message"
+          defaultMessage="Loading..."
+          description="Loading message when a program record is fetching data."
+        />
+      </p>
+    </>
+  );
+
   const renderData = () => {
     if (isLoaded) {
       if (hasNoData) {
         return renderCredentialsServiceIssueAlert();
       }
+      if (isNotFound) {
+        return renderNotFound();
+      }
       return renderProgramDetails();
     }
-    return renderNotFound();
+    return renderLoading();
   };
 
   return (


### PR DESCRIPTION
* While a program record is loading we now get a loading message instead of an error message
* spun off a second private ticket APER-2924, to fix the API problem which makes it impossible to accurately report that a URL is invalid
* Left the stub method in place because I didn't want to lose the translation strings people have made.

FIXES: APER-2190