### PR TITLE
feat!: Remove unused feature flag

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -20,7 +20,6 @@ SEGMENT_KEY=''
 SITE_NAME=localhost
 USER_INFO_COOKIE_NAME='edx-user-info'
 SUPPORT_URL_LEARNER_RECORDS='https://support.edx.org/hc/en-us/sections/360001216693-Learner-records'
-USE_LR_MFE='true'
 APP_ID=''
 MFE_CONFIG_API_URL=''
 ENABLE_VERIFIABLE_CREDENTIALS='true'

--- a/README.rst
+++ b/README.rst
@@ -77,16 +77,15 @@ Environment Variables/Setup Notes
 
 Currently, this MFE is not intergrated into the devstack, and must be run locally. This MFE requires credentials to be running, and will use a REST API from the Credentials IDA located at `credentials/apps/records/rest_api`.
 
-Credentials uses 2 enviroment variables to link to this MFE:
+Credentials requires configuring a Django setting to support directing traffic to the Learner Record MFE:
 
-* ``USE_LEARNER_RECORD_MFE`` -- Toggles the navigation in credentials to redirect to this MFE
-* ``LEARNER_RECORD_MFE_RECORDS_PAGE_URL`` -- The URL for the base URL of this MFE
+* ``LEARNER_RECORD_MFE_RECORDS_PAGE_URL`` -- The base URL of the Learne Record MFE
 
-More details for these flags can be found in the base configuration of credentials: ``credentials/settings/base``
-This MFE has 2 flags of its own:
+For more info, see the Learner Records documentation on ReadTheDocs: https://edx-credentials.readthedocs.io/en/latest/learner_records.html.
+
+This MFE has a setting of its own:
 
 * ``SUPPORT_URL_LEARNER_RECORDS`` -- A link to a help/support center for learners who run into problems whilst trying to share their records
-* ``USE_LR_MFE`` -- A toggle that when on, uses the MFE to host shared records instead of the the old UI inside of credentials
 
 Verifiable Credentials
 ......................

--- a/src/components/ProgramRecordsList/ProgramRecordsList.jsx
+++ b/src/components/ProgramRecordsList/ProgramRecordsList.jsx
@@ -115,7 +115,7 @@ function ProgramRecordsList() {
             <div className="d-flex align-items-center pt-3 pt-lg-0">
               <Hyperlink
                 variant="muted"
-                destination={getConfig().USE_LR_MFE ? `/${record.uuid}` : `${getConfig().CREDENTIALS_BASE_URL}/records/programs/${record.uuid}/`}
+                destination={`/${record.uuid}`}
               >
                 <Button variant="outline-primary">
                   <FormattedMessage

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -25,30 +25,26 @@ subscribe(APP_READY, () => {
       <HelmetProvider>
         <Head />
         <Header />
-        {getConfig().USE_LR_MFE ? (
-          <Routes>
+        <Routes>
+          <Route
+            path={ROUTES.PROGRAM_RECORDS}
+            element={<AuthenticatedPageRoute><ProgramRecordsList /></AuthenticatedPageRoute>}
+          />
+          <Route
+            path={ROUTES.PROGRAM_RECORD_SHARED}
+            element={<ProgramRecord isPublic />}
+          />
+          <Route
+            path={ROUTES.PROGRAM_RECORD_ITEM}
+            element={<AuthenticatedPageRoute><ProgramRecord isPublic={false} /></AuthenticatedPageRoute>}
+          />
+          {getConfig().ENABLE_VERIFIABLE_CREDENTIALS && (
             <Route
-              path={ROUTES.PROGRAM_RECORDS}
-              element={<AuthenticatedPageRoute><ProgramRecordsList /></AuthenticatedPageRoute>}
+              path={ROUTES.VERIFIABLE_CREDENTIALS}
+              element={<AuthenticatedPageRoute><ProgramCertificatesList /></AuthenticatedPageRoute>}
             />
-            {getConfig().ENABLE_VERIFIABLE_CREDENTIALS && (
-              <Route
-                path={ROUTES.VERIFIABLE_CREDENTIALS}
-                element={<AuthenticatedPageRoute><ProgramCertificatesList /></AuthenticatedPageRoute>}
-              />
-            )}
-            <Route
-              path={ROUTES.PROGRAM_RECORD_SHARED}
-              element={<ProgramRecord isPublic />}
-            />
-            <Route
-              path={ROUTES.PROGRAM_RECORD_ITEM}
-              element={<AuthenticatedPageRoute><ProgramRecord isPublic={false} /></AuthenticatedPageRoute>}
-            />
-          </Routes>
-        ) : (
-          <ProgramRecordsList />
-        )}
+          )}
+        </Routes>
         <Footer />
       </HelmetProvider>
     </AppProvider>,
@@ -65,7 +61,6 @@ initialize({
     config: () => {
       mergeConfig({
         SUPPORT_URL_LEARNER_RECORDS: process.env.SUPPORT_URL_LEARNER_RECORDS || '',
-        USE_LR_MFE: process.env.USE_LR_MFE || false,
         ENABLE_VERIFIABLE_CREDENTIALS: process.env.ENABLE_VERIFIABLE_CREDENTIALS || false,
         SUPPORT_URL_VERIFIABLE_CREDENTIALS: process.env.SUPPORT_URL_VERIFIABLE_CREDENTIALS || '',
       }, 'LearnerRecordConfig');


### PR DESCRIPTION
[APER-2922]

This PR removes the `USE_LR_MFE` feature flag. This feature flag was initially added to redirect learners back to the legacy frontend in Credentials when viewing a Program Record. This was so we could release the Learner Record MFE in phases while we were implementing the design.

Now that the legacy frontend has been removed from Credentials, this functionality and feature flag is no longer needed.