### PR TITLE
fix: fix icon color

### DIFF
--- a/module.config.js.example
+++ b/module.config.js.example
@@ -1,0 +1,31 @@
+module.exports = {
+  /*
+  Modules you want to use from local source code.  Adding a module here means that when this app
+  runs its build, it'll resolve the source from peer directories of this app.
+
+  moduleName: the name you use to import code from the module.
+  dir: The relative path to the module's source code.
+  dist: The sub-directory of the source code where it puts its build artifact.  Often "dist".
+
+  To use a module config:
+
+  1. Copy module.config.js.example and remove the '.example' extension
+  2. Uncomment modules below in the localModules array to load them from local source code.
+  3. Remember to re-build the production builds of those local modules if they have one.
+     See note below.
+  */
+  localModules: [
+    /*********************************************************************************************
+     IMPORTANT NOTE: If any of the below packages (like paragon or frontend-platform) have a build
+     step that populates their 'dist' directories, you must manually run that step.  For paragon
+     and frontend-platform, for instance, you need to run `npm run build` in the repo before
+     module.config.js will work.
+    **********************************************************************************************/
+
+    // { moduleName: '@edx/brand', dir: '../brand-openedx' }, // replace with your brand checkout
+    // { moduleName: '@edx/paragon/scss/core', dir: '../paragon', dist: 'scss/core' },
+    // { moduleName: '@edx/paragon/icons', dir: '../paragon', dist: 'icons' },
+    // { moduleName: '@edx/paragon', dir: '../paragon', dist: 'dist' },
+    // { moduleName: '@edx/frontend-platform', dir: '../frontend-platform', dist: 'dist' },
+  ],
+};

--- a/src/components/ProgramRecord/ProgramRecord.scss
+++ b/src/components/ProgramRecord/ProgramRecord.scss
@@ -7,75 +7,66 @@
 
     .program-record-nav {
         @extend .d-flex, .justify-content-between, .mb-3;
-    
+
         .program-record-actions {
             @extend .d-flex;
             gap: 0.5rem;
-    
-            .send-record-button span.btn-icon-before {
-                filter: invert(100%) sepia(97%) saturate(0%) hue-rotate(70deg) brightness(104%) contrast(105%);
-            }
-    
-            .copy-record-button:hover span.btn-icon-before,
-            .copy-record-button:focus span.btn-icon-before {
-                filter: invert(100%) sepia(97%) saturate(0%) hue-rotate(70deg) brightness(104%) contrast(105%);
-            }
         }
-        
+
         .download-record {
             @extend .d-flex, .flex-row-reverse;
         }
     }
-    
+
     .program-record {
-    
+
         .program-record-header {
-    
+
             .program-headings {
                 @extend .d-flex, .justify-content-between;
                 color: $primary-500;
-    
+
                 h4 {
                     color: inherit;
                 }
-    
+
                 .program-title {
                     @extend .d-flex, .flex-column;
-        
+
                     .heading-label {
                         text-transform: capitalize;
                     }
-    
+
                     h1 {
                         color: inherit;
                     }
                 }
             }
-    
+
             .program-status {
                 @extend .d-flex, .align-items-center;
                 gap: 0.5rem;
-    
+
                 span.badge {
                     @extend .d-flex;
                 }
-    
+
                 span.updated {
                     @extend .small;
                 }
             }
-    
+
             .learner-info {
                 @extend .d-flex;
                 gap: 0.25rem;
             }
         }
-    
+
         .program-record-grades {
             overflow: auto;
         }
     }
-    
+
     .help {
         color: $primary-500;
     }


### PR DESCRIPTION
[APER-2969]

This PR removes a piece of custom CSS we wrote to invert colors of icons under certain circumstances. This was originally added to resolve a problem with Paragon that has since been resolved (and is now the source of the icon color problem).

Problem today on Stage (with edX.org branding):
![image](https://github.com/openedx/frontend-app-learner-record/assets/3229735/7008d884-2808-4214-9d40-3bb2f3b6e006)

After changes (with edX.org branding):
![image](https://github.com/openedx/frontend-app-learner-record/assets/3229735/34e0051d-2366-495d-af18-5b599d2ada2b)

After changes (with Open edX branding):
![image](https://github.com/openedx/frontend-app-learner-record/assets/3229735/e1d29ba1-5881-470d-9caa-ce31ac09511e)
