### PR TITLE
feat: Add a fluid container to allow for limiting the maximum width of the content [backport from master]

### DIFF
--- a/src/components/ProgramCertificatesList/ProgramCertificatesList.jsx
+++ b/src/components/ProgramCertificatesList/ProgramCertificatesList.jsx
@@ -160,19 +160,21 @@ function ProgramCertificatesList({ intl }) {
   );
 
   return (
-    <main id="main-content" className="pt-5 pb-5 pl-4 pr-4" tabIndex="-1">
-      {renderProfile()}
-      <NavigationBar />
-      <h1 className="h3 pl-3 pr-3 mb-4">
-        {intl.formatMessage(messages.credentialsHeader)}
-      </h1>
-      {renderData()}
-      {renderHelp()}
-      <ProgramCertificateModal
-        isOpen={modalIsOpen}
-        close={closeModal}
-        data={verifiableCredentialIssuanceData}
-      />
+    <main id="main-content" className="pt-5 pb-5" tabIndex="-1">
+      <div className="container-fluid">
+        {renderProfile()}
+        <NavigationBar />
+        <h1 className="h3 pl-3 pr-3 mb-4">
+          {intl.formatMessage(messages.credentialsHeader)}
+        </h1>
+        {renderData()}
+        {renderHelp()}
+        <ProgramCertificateModal
+          isOpen={modalIsOpen}
+          close={closeModal}
+          data={verifiableCredentialIssuanceData}
+        />
+      </div>
     </main>
   );
 }

--- a/src/components/ProgramCertificatesList/ProgramCertificatesList.jsx
+++ b/src/components/ProgramCertificatesList/ProgramCertificatesList.jsx
@@ -160,7 +160,7 @@ function ProgramCertificatesList({ intl }) {
   );
 
   return (
-    <main id="main-content" className="pt-5 pb-5" tabIndex="-1">
+    <main id="main-content" className="pt-5 pb-5 pl-4 pr-4" tabIndex="-1">
       <div className="container-fluid">
         {renderProfile()}
         <NavigationBar />

--- a/src/components/ProgramRecordsList/ProgramRecordsList.jsx
+++ b/src/components/ProgramRecordsList/ProgramRecordsList.jsx
@@ -174,7 +174,7 @@ function ProgramRecordsList() {
   );
 
   return (
-    <main id="main-content" className="pt-5 pb-5" tabIndex="-1">
+    <main id="main-content" className="pt-5 pb-5 pl-4 pr-4" tabIndex="-1">
       <div className="container-fluid">
         {renderProfile()}
         <NavigationBar />

--- a/src/components/ProgramRecordsList/ProgramRecordsList.jsx
+++ b/src/components/ProgramRecordsList/ProgramRecordsList.jsx
@@ -174,18 +174,20 @@ function ProgramRecordsList() {
   );
 
   return (
-    <main id="main-content" className="pt-5 pb-5 pl-4 pr-4" tabIndex="-1">
-      {renderProfile()}
-      <NavigationBar />
-      <h1 className="h3 pl-3 pr-3 mb-4">
-        <FormattedMessage
-          id="records.header"
-          defaultMessage="My Learner Records"
-          description="Header for the Learner Records page"
-        />
-      </h1>
-      {renderData()}
-      {renderHelp()}
+    <main id="main-content" className="pt-5 pb-5" tabIndex="-1">
+      <div className="container-fluid">
+        {renderProfile()}
+        <NavigationBar />
+        <h1 className="h3 pl-3 pr-3 mb-4">
+          <FormattedMessage
+            id="records.header"
+            defaultMessage="My Learner Records"
+            description="Header for the Learner Records page"
+          />
+        </h1>
+        {renderData()}
+        {renderHelp()}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
This is backport from master https://github.com/openedx/frontend-app-learner-record/pull/276

Our proposal is to add `<div class="container-fluid">` inside the `<main id="main-content">` block. This will allow limiting the maximum width of the content when necessary. Otherwise, the content will span the entire width of the page, as it would without this div.

Also classes `pl-4` and `pr-4` were removed from main-content, because `container-fluid` already has left and right paddings

Example screenshot width content max-width
![Снимок экрана 2024-02-07 в 23 13 05](https://github.com/openedx/frontend-app-learner-record/assets/19806032/b0a52fb2-baad-4794-b23c-88835a479553)
