### PR TITLE
fix: internal routing ignores public path

### DIFF
--- a/src/components/ProgramRecord/ProgramRecord.jsx
+++ b/src/components/ProgramRecord/ProgramRecord.jsx
@@ -21,6 +21,7 @@ import ProgramRecordTable from './ProgramRecordTable';
 import RecordsHelp from './RecordsHelp';
 import ProgramRecordAlert from '../ProgramRecordAlert';
 import SendLearnerRecordModal from '../ProgramRecordSendModal';
+import createCorrectInternalRoute from '../../utils';
 
 import getProgramDetails from './data/service';
 
@@ -81,7 +82,7 @@ function ProgramRecord({ isPublic }) {
       className="back-to-records"
     >
       <Hyperlink
-        destination="/"
+        destination={createCorrectInternalRoute('/')}
         variant="muted"
       >
         <FormattedMessage

--- a/src/components/ProgramRecordsList/ProgramRecordsList.jsx
+++ b/src/components/ProgramRecordsList/ProgramRecordsList.jsx
@@ -12,6 +12,7 @@ import _ from 'lodash';
 
 import NavigationBar from '../NavigationBar';
 
+import createCorrectInternalRoute from '../../utils';
 import getProgramRecords from './data/service';
 
 function ProgramRecordsList() {
@@ -115,7 +116,7 @@ function ProgramRecordsList() {
             <div className="d-flex align-items-center pt-3 pt-lg-0">
               <Hyperlink
                 variant="muted"
-                destination={`/${record.uuid}`}
+                destination={createCorrectInternalRoute(`/${record.uuid}`)}
               >
                 <Button variant="outline-primary">
                   <FormattedMessage

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,20 @@
+import { getConfig, getPath } from '@edx/frontend-platform';
+
+/**
+ * Create a correct inner path depend on config PUBLIC_PATH.
+ * @param {string} checkPath - the internal route path that is validated
+ * @returns {string} - the correct internal route path
+ */
+export default function createCorrectInternalRoute(checkPath) {
+  let basePath = getPath(getConfig().PUBLIC_PATH);
+
+  if (basePath.endsWith('/')) {
+    basePath = basePath.slice(0, -1);
+  }
+
+  if (!checkPath.startsWith(basePath)) {
+    return `${basePath}${checkPath}`;
+  }
+
+  return checkPath;
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,48 @@
+import { getConfig, getPath } from '@edx/frontend-platform';
+
+import createCorrectInternalRoute from './utils';
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(),
+  ensureConfig: jest.fn(),
+  getPath: jest.fn(),
+}));
+
+describe('LearnerRecord utils', () => {
+  describe('createCorrectInternalRoute', () => {
+    beforeEach(() => {
+      getConfig.mockReset();
+      getPath.mockReset();
+    });
+
+    it('returns the correct internal route when checkPath is not prefixed with basePath', () => {
+      getConfig.mockReturnValue({ PUBLIC_PATH: 'example.com' });
+      getPath.mockReturnValue('/');
+
+      const checkPath = '/some/path';
+      const result = createCorrectInternalRoute(checkPath);
+
+      expect(result).toBe('/some/path');
+    });
+
+    it('returns the input checkPath when it is already prefixed with basePath', () => {
+      getConfig.mockReturnValue({ PUBLIC_PATH: 'example.com' });
+      getPath.mockReturnValue('/learner-record');
+
+      const checkPath = '/learner-record/some/path';
+      const result = createCorrectInternalRoute(checkPath);
+
+      expect(result).toBe('/learner-record/some/path');
+    });
+
+    it('handles basePath ending with a slash correctly', () => {
+      getConfig.mockReturnValue({ PUBLIC_PATH: 'example.com/' });
+      getPath.mockReturnValue('/learner-record/');
+
+      const checkPath = '/some/path';
+      const result = createCorrectInternalRoute(checkPath);
+
+      expect(result).toBe('/learner-record/some/path');
+    });
+  });
+});


### PR DESCRIPTION
## Description
Internal routes don't respect the PUBLIC_PATH which leads to redirecting to incorrect URLs.

Add a new util function for constructing the correct internal route URL.

## Steps to reproduce
You'll need an instance deployed with the common domain for MFEs (each MFE should have the PUBLIC_PATH set).
You can reproduce it using Tutor.
**Devstack uses separate domains for each MFE so you won't reproduce the issue there!**

1. Set up a program
2. Go to Profile and click on "View My Records" button 
![Screenshot 2024-03-28 at 17 48 13](https://github.com/openedx/frontend-app-learner-record/assets/47273130/18830d64-1e54-40d9-8f58-71fdcb060b34)
3. Click on "View Program Record" button 
![Screenshot 2024-03-28 at 17 49 02](https://github.com/openedx/frontend-app-learner-record/assets/47273130/46a6a461-ec57-475b-b68a-9242bfb86ddb)

## Actual result
PUBLIC_PATH for Learner Record MFE is ignored, and the user is redirected to the wrong URL 
![image](https://github.com/openedx/frontend-app-learner-record/assets/47273130/aa2a7fc5-79f1-4126-bf56-36cd2cbc3714)

The same result on the Program Records page for the "Back To My Records" link 
![Screenshot 2024-03-28 at 17 55 21](https://github.com/openedx/frontend-app-learner-record/assets/47273130/a828ca50-8f97-4876-ae02-27a43a06a7aa)

## Expected result
Correct internal routing is performed

## Notes
I'll create a backport PR for Quince soon