### PR TITLE
revert: "chore(deps): update dependency @testing-library/react to v14"

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@edx/reactifex": "2.2.0",
     "@openedx/frontend-build": "13.0.29",
     "@testing-library/jest-dom": "6.4.2",
-    "@testing-library/react": "14.2.2",
+    "@testing-library/react": "12.1.5",
     "axios-mock-adapter": "1.22.0",
     "babel-plugin-react-intl": "8.2.25",
     "glob": "10.3.10",


### PR DESCRIPTION
This reverts commit https://github.com/openedx/frontend-app-learner-record/commit/38e0f7abe5a1790fbbb04f5e79338ebc0a53a0c5. This version of testing-library/react doesn't play well with our current version of React.

We shouldn't upgrade this library until we're running a newer version of React in this MFE.