### PR TITLE
feat: UI improvements

### DIFF
--- a/src/components/ProgramRecord/ProgramRecord.jsx
+++ b/src/components/ProgramRecord/ProgramRecord.jsx
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 
 import {
-  Info, ArrowBack,
+  Info, ChevronLeft,
 } from '@edx/paragon/icons';
 import {
-  Alert, Container, Button, Hyperlink,
+  Alert, Container, Hyperlink,
 } from '@edx/paragon';
 
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
@@ -76,22 +76,17 @@ function ProgramRecord({ isPublic }) {
   };
 
   const renderBackButton = () => (
-    <Button
-      variant="tertiary"
-      iconBefore={ArrowBack}
-      className="back-to-records"
+    <Hyperlink
+      destination={createCorrectInternalRoute('/')}
+      variant="muted"
     >
-      <Hyperlink
-        destination={createCorrectInternalRoute('/')}
-        variant="muted"
-      >
-        <FormattedMessage
-          id="link.back.to.records"
-          defaultMessage="Back to My Records"
-          description="A link that takes the user back to their program records"
-        />
-      </Hyperlink>
-    </Button>
+      <ChevronLeft />
+      <FormattedMessage
+        id="link.back.to.records"
+        defaultMessage="Back to My Records"
+        description="A link that takes the user back to their program records"
+      />
+    </Hyperlink>
   );
 
   const renderProgramDetails = () => (

--- a/src/components/ProgramRecord/RecordsHelp.jsx
+++ b/src/components/ProgramRecord/RecordsHelp.jsx
@@ -6,13 +6,13 @@ import { Hyperlink } from '@edx/paragon';
 function RecordsHelp({ helpUrl }) {
   return (
     <section className="help">
-      <h2>
+      <h3 className="h5">
         <FormattedMessage
           id="help.section.header"
           defaultMessage="Questions about Learner Records?"
           description="A header for the help section"
         />
-      </h2>
+      </h3>
       <p>
         <FormattedMessage
           id="help.section.content.with.link"

--- a/src/components/ProgramRecordSendModal/SendLearnerRecordModal.scss
+++ b/src/components/ProgramRecordSendModal/SendLearnerRecordModal.scss
@@ -15,12 +15,6 @@
 
         > div {
             width: 100%;
-            @extend .d-flex;
-
-            input[type=checkbox] {
-                margin-top: 4px;
-                flex-shrink: 0;
-            }
         }
     }
 }

--- a/src/components/ProgramRecordSendModal/SendLearnerRecordModal.scss
+++ b/src/components/ProgramRecordSendModal/SendLearnerRecordModal.scss
@@ -15,6 +15,12 @@
 
         > div {
             width: 100%;
+            @extend .d-flex;
+
+            input[type=checkbox] {
+                margin-top: 4px;
+                flex-shrink: 0;
+            }
         }
     }
 }


### PR DESCRIPTION
This is backport from master - https://github.com/openedx/frontend-app-learner-record/pull/318

**Minor fix for Back to My Records button**

**First proposal:** make the button look the same as the button on the records page

**Second proposal:** remove the `<a>` tag from the `<button>` tag. The current approach is not recommended due to potential accessibility and semantic issues

<img width="1840" alt="Снимок экрана 2024-04-04 в 00 59 00" src="https://github.com/openedx/frontend-app-learner-record/assets/19806032/40f72d5d-b94a-4d17-a30f-48b46ee906c9">

**Decrease font size for the `Questions about Learner Records` title - to match with the same title on Records page**

<img width="1840" alt="Снимок экрана 2024-04-04 в 01 10 26" src="https://github.com/openedx/frontend-app-learner-record/assets/19806032/1500eace-67d2-46a9-893c-bc790c33681c">

<img width="1840" alt="Снимок экрана 2024-04-04 в 01 14 52" src="https://github.com/openedx/frontend-app-learner-record/assets/19806032/7f67b9fd-b536-43c2-8bba-7b0c83e7637a">

**Send Program Record modal window - checkboxes alignment**

Before

<img width="1796" alt="Снимок экрана 2024-04-04 в 14 11 01" src="https://github.com/openedx/frontend-app-learner-record/assets/19806032/55d40be0-7a11-4e26-b102-2733cac4db7e">

After

<img width="1840" alt="Снимок экрана 2024-04-04 в 14 11 38" src="https://github.com/openedx/frontend-app-learner-record/assets/19806032/1fca656c-91bc-4430-bdb4-b20144872bf8">
