### PR TITLE
chore: add codeowners files to .github workflow

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @openedx/2U-aperture


### PR DESCRIPTION
This PR adds the 2U-Aperture team as code owners of Learner Record MFE. This will allow us more visibility on PRs from contributors outside of the team and visibility for those contributors to request a code review from our team. 


APER-3261