### PR TITLE
chore(deps): upgrade paragon v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@edx/frontend-app-learner-record",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
@@ -21,7 +20,7 @@
         "@fortawesome/free-solid-svg-icons": "6.5.2",
         "@fortawesome/react-fontawesome": "0.2.0",
         "@openedx/frontend-plugin-framework": "^1.1.0",
-        "@openedx/paragon": "^21.11.3",
+        "@openedx/paragon": "^22.2.2",
         "axios": "0.28.1",
         "babel-polyfill": "6.26.0",
         "core-js": "3.36.1",
@@ -49,7 +48,7 @@
         "glob": "10.3.12",
         "husky": "9.0.11",
         "jest": "^28.0.0",
-        "patch-package": "8.0.0",
+        "patch-package": "^8.0.0",
         "resize-observer-polyfill": "^1.5.1",
         "rosie": "2.1.1"
       }
@@ -5099,9 +5098,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "21.13.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-21.13.1.tgz",
-      "integrity": "sha512-sLL+Z3ZWIRM6x+OrKZV0S7/SQpEcSeRcDm7E3FzhsnAWudsJCTELvSW+84uy/8dwV7mJhttsBPqQEtNafbCyYA==",
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.2.2.tgz",
+      "integrity": "sha512-kHljO3JjLQzkk16aOIUN+LbSVMF9a6jkO0G9CmAYhYRDZMpWlP8qUz5uWk7pJvQdCoqD2dL9Cp9YqhWLXCa2kQ==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "i18n_extract": "fedx-scripts formatjs extract",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx .",
-    "postinstall": "patch-package",
     "serve": "fedx-scripts serve",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
@@ -46,7 +45,7 @@
     "@fortawesome/free-solid-svg-icons": "6.5.2",
     "@fortawesome/react-fontawesome": "0.2.0",
     "@openedx/frontend-plugin-framework": "^1.1.0",
-    "@openedx/paragon": "^21.11.3",
+    "@openedx/paragon": "^22.2.2",
     "axios": "0.28.1",
     "babel-polyfill": "6.26.0",
     "core-js": "3.36.1",
@@ -74,7 +73,7 @@
     "glob": "10.3.12",
     "husky": "9.0.11",
     "jest": "^28.0.0",
-    "patch-package": "8.0.0",
+    "patch-package": "^8.0.0",
     "resize-observer-polyfill": "^1.5.1",
     "rosie": "2.1.1"
   }


### PR DESCRIPTION
Upgrade to Paragon v22. The breaking changes are for components that are not used by this MFE (see [release notes](https://github.com/openedx/paragon/releases/tag/v22.0.0))