### PR TITLE
test: Remove support for Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ on: [push, pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [18, 20]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -14,7 +11,7 @@ jobs:
     - name: Setup Nodejs
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node }}
+        node-version-file: '.nvmrc'
     - name: Install dependencies
       run: npm ci
     - name: Validate package-lock.json changes

--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   version-check:
-    uses: openedx/.github/.github/workflows/lockfile-check-v20.yml@master
+    uses: openedx/.github/.github/workflows/lockfileversion-check-v3.yml@master


### PR DESCRIPTION
### Description

Complete the upgrade to Node 20 by removing the Node 18 CI check and going back to using `.nvmrc` as the source of truth for which version to use.

See [the tracking issue](https://github.com/openedx/frontend-app-learner-record/issues/298) for futher information.