### PR TITLE
fix: remove showLaunchIcon from Hyperlink component

### DIFF
--- a/src/components/ProgramRecordsList/ProgramRecordsList.jsx
+++ b/src/components/ProgramRecordsList/ProgramRecordsList.jsx
@@ -163,7 +163,6 @@ function ProgramRecordsList() {
       <Hyperlink
         destination={`${getConfig().SUPPORT_URL_LEARNER_RECORDS}`}
         target="_blank"
-        showLaunchIcon={false}
       >
         <FormattedMessage
           id="records.help.link"


### PR DESCRIPTION
This PR adds the hyperlink icon to the statement that redirects to the record's help page.

### Issue
https://github.com/openedx/frontend-app-learner-record/issues/456

###  Screenshots
![image](https://github.com/user-attachments/assets/dbec3e06-c2f0-4614-83d1-30fc41b8dc3c)
