### PR TITLE
chore: make sure links point to MFE not legacy

### DIFF
--- a/src/components/ProgramCertificatesList/ProgramCertificatesList.jsx
+++ b/src/components/ProgramCertificatesList/ProgramCertificatesList.jsx
@@ -86,7 +86,7 @@ function ProgramCertificatesList({ intl }) {
     const { username } = getAuthenticatedUser();
     return (
       <Hyperlink
-        destination={`${getConfig().LMS_BASE_URL}/u/${username}`}
+        destination={`${getConfig().ACCOUNT_PROFILE_URL}/u/${username}`}
         className="mb-4 d-inline-block muted-link pl-3 pr-3"
       >
         <ChevronLeft className="mb-1" />

--- a/src/components/ProgramRecordsList/ProgramRecordsList.jsx
+++ b/src/components/ProgramRecordsList/ProgramRecordsList.jsx
@@ -46,7 +46,7 @@ function ProgramRecordsList() {
     const { username } = getAuthenticatedUser();
     return (
       <Hyperlink
-        destination={`${getConfig().LMS_BASE_URL}/u/${username}`}
+        destination={`${getConfig().ACCOUNT_PROFILE_URL}/u/${username}`}
         className="mb-4 d-inline-block muted-link pl-3 pr-3"
       >
         <ChevronLeft className="mb-1" />


### PR DESCRIPTION
now that the legacy profile and account pages have been removed, we need to make sure that all of the links point to the MFE URLs; we were relying on the legacy applications to do redirection before.

FIXES: APER-3884
FIXES: openedx/public-engineering#71