### PR TITLE
fix(deps): update `frontend-platform` to `^8.3.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/frontend-component-footer": "14.2.0",
         "@edx/frontend-component-header": "^5.6.0",
-        "@edx/frontend-platform": "8.2.1",
+        "@edx/frontend-platform": "^8.3.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "6.7.2",
         "@fortawesome/free-brands-svg-icons": "6.7.2",
@@ -2016,15 +2016,15 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.2.1.tgz",
-      "integrity": "sha512-Pid7feVSr81Kl+Oeuh5sZR2caDyCvOz191dmtSYFKKR5lAyOBetc14GMZ9s/TYneeiR0bCbzUIWSl17eRuZrJw==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.3.1.tgz",
+      "integrity": "sha512-wDCCFtbWdxk8N/ExIGd/etyidF9YewaRdyGix2nSTujdfKZU/+2cObRxGkardGHREQDGrvqCPW5tmcSNedAIIg==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "1.7.9",
+        "axios": "1.8.2",
         "axios-cache-interceptor": "1.6.2",
         "form-urlencoded": "4.1.4",
         "glob": "7.2.3",
@@ -2047,7 +2047,7 @@
       },
       "peerDependencies": {
         "@openedx/frontend-build": ">= 14.0.0",
-        "@openedx/paragon": ">= 21.5.7 < 23.0.0",
+        "@openedx/paragon": ">= 21.5.7 < 24.0.0",
         "prop-types": ">=15.7.2 <16.0.0",
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
@@ -5525,9 +5525,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-component-footer": "14.2.0",
     "@edx/frontend-component-header": "^5.6.0",
-    "@edx/frontend-platform": "8.2.1",
+    "@edx/frontend-platform": "^8.3.1",
     "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "6.7.2",
     "@fortawesome/free-brands-svg-icons": "6.7.2",

--- a/src/components/NavigationBar/test/NavigationBar.test.jsx
+++ b/src/components/NavigationBar/test/NavigationBar.test.jsx
@@ -32,14 +32,15 @@ describe('navigation-bar', () => {
     waitFor(() => { expect(container.innerHTML).toHaveLength(0); });
   });
 
-  it('renders the component with enabled the Verifiable Credentials functionality', () => {
+  it('renders the component with enabled the Verifiable Credentials functionality', async () => {
     render(<NavigationBar />);
-    expect(screen.getByText('My Learner Records')).toBeTruthy();
-    expect(screen.getByText('Verifiable Credentials')).toBeTruthy();
+    await screen.findByText('My Learner Records');
+    await screen.findByText('Verifiable Credentials');
   });
 
-  it('redirects the appropriate route on tab click', () => {
+  it('redirects the appropriate route on tab click', async () => {
     render(<NavigationBar />);
+    await screen.findByText('Verifiable Credentials');
     fireEvent.click(screen.getByText('Verifiable Credentials'));
     expect(mockedNavigator).toHaveBeenCalledWith('/verifiable-credentials');
   });


### PR DESCRIPTION
This PR updates the `frontend-platform` dependency to `^8.3.1`, and fixes a few tests the broke in the process.

The following tests were failing (see https://github.com/openedx/frontend-app-learner-record/actions/runs/13758418634/job/38469530685)
*  navigation-bar › renders the component with enabled the Verifiable Credentials functionality
    * Made it `async`
    * Switched from `expect`/`getByText`/`toBeTruthy` to [`findByText`](https://testing-library.com/docs/dom-testing-library/api-async/#findby-queries)
*  navigation-bar › redirects the appropriate route on tab click
    * Made it `async`
    * Added an `await screen.findByText` after render to ensure we have something to click